### PR TITLE
add restart before exectuing mongo shell commands

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,6 +17,9 @@
 - name: Configure log directory
   file: state=directory path={{ mongodb_conf_logpath | dirname }} owner={{mongodb_user}} group={{mongodb_user}} mode=0755
 
+- name: Restart mongodb with new config
+  service: name={{ mongodb_daemon_name }} state=restarted
+
 - name: Run mongoshell commands
   command: mongo {{ item.key }} --eval "{{ item.value|join('\n') }}"
   with_dict: mongodb_shell


### PR DESCRIPTION
when you want to bring up a replica set using rs.initialize() mongo will complain that it is not running with the --replSet even though you can specify that in the config. To fix that we need to restart mongo to apply the config before running the shell commands.