### PR TITLE
Fix for bools and ints being written with quotes

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -1,24 +1,24 @@
 # {{ ansible_managed }}
 
-auth = {{ mongodb_conf_auth|to_nice_json }}
+auth = {{ mongodb_conf_auth|to_nice_json|bool }}
 bind_ip = {{ mongodb_conf_bind_ip }}
-cpu = {{ mongodb_conf_cpu|to_nice_json }}
+cpu = {{ mongodb_conf_cpu|to_nice_json|bool }}
 dbpath = {{ mongodb_conf_dbpath }}
-fork = {{ mongodb_conf_fork|to_nice_json }}
-httpinterface = {{ mongodb_conf_httpinterface|to_nice_json }}
-ipv6 = {{ mongodb_conf_ipv6|to_nice_json }}
-journal = {{ mongodb_conf_journal|to_nice_json }}
-logappend = {{ mongodb_conf_logappend|to_nice_json }}
+fork = {{ mongodb_conf_fork|to_nice_json|bool }}
+httpinterface = {{ mongodb_conf_httpinterface|to_nice_json|bool }}
+ipv6 = {{ mongodb_conf_ipv6|to_nice_json|bool }}
+journal = {{ mongodb_conf_journal|to_nice_json|bool }}
+logappend = {{ mongodb_conf_logappend|to_nice_json|bool }}
 logpath = {{ mongodb_conf_logpath }}
-maxConns = {{ mongodb_conf_maxConns }}
-noprealloc = {{ mongodb_conf_noprealloc|to_nice_json }}
-noscripting = {{ mongodb_conf_noscripting|to_nice_json }}
-notablescan = {{ mongodb_conf_notablescan|to_nice_json }}
-port = {{ mongodb_conf_port }}
-quota = {{ mongodb_conf_quota|to_nice_json }}
-quotaFiles = {{ mongodb_conf_quotaFiles }}
-syslog = {{ mongodb_conf_syslog|to_nice_json }}
-smallfiles = {{ mongodb_conf_smallfiles|to_nice_json }}
+maxConns = {{ mongodb_conf_maxConns|int }}
+noprealloc = {{ mongodb_conf_noprealloc|to_nice_json|bool }}
+noscripting = {{ mongodb_conf_noscripting|to_nice_json|bool }}
+notablescan = {{ mongodb_conf_notablescan|to_nice_json|bool }}
+port = {{ mongodb_conf_port|int }}
+quota = {{ mongodb_conf_quota|to_nice_json|bool }}
+quotaFiles = {{ mongodb_conf_quotaFiles|int }}
+syslog = {{ mongodb_conf_syslog|to_nice_json|bool }}
+smallfiles = {{ mongodb_conf_smallfiles|to_nice_json|bool }}
 {% if mongodb_conf_replSet %}
 # Replica set options:
 replSet = {{ mongodb_conf_replSet }}


### PR DESCRIPTION
This happens if the mongodb_conf_* value is build via a Jinja2 expression in ansible.