### PR TITLE
Added multiple Mongo version support.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,5 +4,5 @@ Contributors:
 * Guillaume Dedrie (https://github.com/guillaumededrie)
 * Jason McVetta (https://github.com/jmcvetta)
 * Joao C Costa (https://github.com/joaocc)
-* Mikołaj Koziarkiewicz (https://github.com/mikkoz)
+* Mikołaj Koziarkiewicz (https://github.com/mikolak-net)
 * Sergey Protko (https://github.com/fesor)

--- a/README.md
+++ b/README.md
@@ -15,16 +15,29 @@ Ansible role which manage [MongoDB](http://www.mongodb.org/)
 ```yaml
 
 mongodb_enabled: yes
-
-mongodb_package: mongodb-org
+mongodb_install: yes
 
 mongodb_additional_packages:
 - python-selinux
 - python-pymongo
 
 mongodb_user: mongodb
-mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' == mongodb_package) else 'mongodb' }}"
 
+mongodb_version: "2.6.11"                        # Fully specified target installation version
+
+# Service setup options
+mongodb_version_config:                          # Custom configuration for major/minor version variants
+  v2.4:
+    daemon: mongodb
+    config_file: mongodb.conf
+  v2.6:
+    daemon: mongod
+    config_file: mongod.conf
+  v3.0:
+    daemon: mongod
+    config_file: mongod.conf
+
+# Config options
 mongodb_conf_auth: no                             # Run with security
 mongodb_conf_bind_ip: 127.0.0.1                   # Comma separated list of ip addresses to listen on
 mongodb_conf_cpu: yes                             # Periodically show cpu and iowait utilization
@@ -35,15 +48,15 @@ mongodb_conf_ipv6: no                             # Enable IPv6 support (disable
 mongodb_conf_journal: no                          # Enable journaling
 mongodb_conf_logappend: yes                       # Append to logpath instead of over-writing
 mongodb_conf_logpath: /var/log/mongodb/{{ mongodb_daemon_name }}.log # Log file to send write to instead of stdout
-mongodb_conf_maxConns: 1000000                    # Max number of simultaneous connections
+mongodb_conf_maxConns: 20000                      # Max number of simultaneous connections
 mongodb_conf_noprealloc: no                       # Disable data file preallocation
 mongodb_conf_noscripting: no                      # Disable scripting engine
 mongodb_conf_notablescan: no                      # Do not allow table scans
 mongodb_conf_port: 27017                          # Specify port number
 mongodb_conf_quota: no                            # Limits each database to a certain number of files
 mongodb_conf_quotaFiles: 8                        # Number of quota files
-mongodb_conf_syslog: no                           # Log to system's syslog facility instead of file
-mongodb_conf_smallfiles: no                       # Sets MongoDB to use a smaller default file size       
+mongodb_conf_syslog: no                           # Log to system's syslog facility instead of file (ignored if logpath set)
+mongodb_conf_smallfiles: no                       # Sets MongoDB to use a smaller default file size
 
 # Replica set options:
 mongodb_conf_replSet:                             # Enable replication <setname>[/<optionalseedhostlist>]
@@ -56,7 +69,7 @@ mongodb_shell: {}                                 # Define mongo shell commands 
 
 
 # MMS Agent
-mongodb_mms_agent_pkg: https://mms.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager_1.4.2.783-1_amd64.deb
+mongodb_mms_agent_pkg: https://mms.mongodb.com/download/agent/automation/mongodb-mms-automation-agent-manager_latest_amd64.deb
 mongodb_mms_group_id: ""
 mongodb_mms_api_key: ""
 mongodb_mms_base_url: https://mms.mongodb.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,15 +3,27 @@
 mongodb_enabled: yes
 mongodb_install: yes
 
-mongodb_package: mongodb-org
-
 mongodb_additional_packages:
 - python-selinux
 - python-pymongo
 
 mongodb_user: mongodb
-mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"
 
+mongodb_version: "2.6.11"                        # Fully specified target installation version
+
+# Service setup options
+mongodb_version_config:                          # Custom configuration for major/minor version variants
+  v2.4:
+    daemon: mongodb
+    config_file: mongodb.conf
+  v2.6:
+    daemon: mongod
+    config_file: mongod.conf
+  v3.0:
+    daemon: mongod
+    config_file: mongod.conf
+
+# Config options
 mongodb_conf_auth: no                             # Run with security
 mongodb_conf_bind_ip: 127.0.0.1                   # Comma separated list of ip addresses to listen on
 mongodb_conf_cpu: yes                             # Periodically show cpu and iowait utilization
@@ -22,14 +34,14 @@ mongodb_conf_ipv6: no                             # Enable IPv6 support (disable
 mongodb_conf_journal: no                          # Enable journaling
 mongodb_conf_logappend: yes                       # Append to logpath instead of over-writing
 mongodb_conf_logpath: /var/log/mongodb/{{ mongodb_daemon_name }}.log # Log file to send write to instead of stdout
-mongodb_conf_maxConns: 1000000                    # Max number of simultaneous connections
+mongodb_conf_maxConns: 20000                      # Max number of simultaneous connections
 mongodb_conf_noprealloc: no                       # Disable data file preallocation
 mongodb_conf_noscripting: no                      # Disable scripting engine
 mongodb_conf_notablescan: no                      # Do not allow table scans
 mongodb_conf_port: 27017                          # Specify port number
 mongodb_conf_quota: no                            # Limits each database to a certain number of files
 mongodb_conf_quotaFiles: 8                        # Number of quota files
-mongodb_conf_syslog: no                           # Log to system's syslog facility instead of file
+mongodb_conf_syslog: no                           # Log to system's syslog facility instead of file (ignored if logpath set)
 mongodb_conf_smallfiles: no                       # Sets MongoDB to use a smaller default file size
 
 # Replica set options:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Configure mongodb
-  template: src=mongod.conf.j2 dest=/etc/mongod.conf owner=root group=root mode=0644
+  template: src=mongod.conf.j2 dest=/etc/{{mongodb_config['config_file']}} owner=root group=root mode=0644
   notify: mongodb restart
 
 - name: Configure log rotation

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -2,16 +2,18 @@
 
 - include_vars: "{{ansible_distribution}}.yml"
 
+- name: Obtain repository config
+  set_fact:
+    mongodb_repository_data: "{{mongodb_repository_config[mongodb_major_minor_version]}}"
+
 - name: Add APT key
-  apt_key: url=http://docs.mongodb.org/10gen-gpg-key.asc id=7F0CEB10
-  when: '"mongodb-org" in mongodb_package'
+  apt_key: keyserver=keyserver.ubuntu.com id=7F0CEB10
 
 - name: Add APT repository
-  apt_repository: repo="{{mongodb_repository}}" update_cache=yes
-  when: '"mongodb-org" in mongodb_package'
+  apt_repository: repo="{{mongodb_repository_data.repository}}" update_cache=yes
 
 - name: Install MongoDB package
-  apt: pkg={{mongodb_package}} state=present
+  apt: pkg="{{mongodb_repository_data.package+'='+mongodb_version}}" state=present
 
 - name: Install additional packages
   apt: pkg={{item}}

--- a/tasks/mongodb.yml
+++ b/tasks/mongodb.yml
@@ -1,4 +1,14 @@
 ---
+- name: Set up configuration parameters 1/3
+  set_fact: mongodb_major_minor_version=v{{mongodb_version[:3]}} # the 'v' is necessary due to Ansible's number autoconversion quirks
+
+- name: Set up configuration parameters 2/3
+  set_fact:
+    mongodb_config: "{{mongodb_version_config[mongodb_major_minor_version]}}"
+
+- name: Set up configuration parameters 3/3
+  set_fact:
+    mongodb_daemon_name: "{{mongodb_config['daemon']}}"
 
 - include: install.deb.yml
   when: ansible_os_family == 'Debian' and mongodb_install

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -17,7 +17,9 @@ notablescan = {{ mongodb_conf_notablescan|to_nice_json|bool }}
 port = {{ mongodb_conf_port|int }}
 quota = {{ mongodb_conf_quota|to_nice_json|bool }}
 quotaFiles = {{ mongodb_conf_quotaFiles|int }}
+{% if mongodb_conf_logpath == '' %}
 syslog = {{ mongodb_conf_syslog|to_nice_json|bool }}
+{% endif %}
 smallfiles = {{ mongodb_conf_smallfiles|to_nice_json|bool }}
 {% if mongodb_conf_replSet %}
 # Replica set options:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,11 @@
 ---
-
-mongodb_repository: deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen
+mongodb_repository_config:
+  v2.4:
+    repository: deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen
+    package: mongodb-10gen
+  v2.6:
+    repository: deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen
+    package: mongodb-org
+  v3.0:
+    repository: deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main
+    package: mongodb-org

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,3 +1,11 @@
 ---
-
-mongodb_repository: deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen
+mongodb_repository_config:
+  v2.4:
+    repository: deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen
+    package: mongodb-10gen
+  v2.6:
+    repository: deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen
+    package: mongodb-org
+  v3.0:
+    repository: deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse
+    package: mongodb-org


### PR DESCRIPTION
Exactly as it says on the tin. Tested several config variants both on Ubuntu Trusty and Debian Wheezy, focusing on settings that cause problems across versions. 

Do note that the role's config spec has been changed in a somewhat non-backward-compatible way - hope that's OK.