### PR TITLE
Make sure mongodb is restarted before shell commands are executed

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,10 +17,13 @@
 - name: Configure log directory
   file: state=directory path={{ mongodb_conf_logpath | dirname }} owner={{mongodb_user}} group={{mongodb_user}} mode=0755
 
-- name: Run mongoshell commands
-  command: mongo {{ item.key }} --eval "{{ item.value|join('\n') }}"
-  with_dict: mongodb_shell
-
 - name: Ensure mongodb is started
   service: name={{ mongodb_daemon_name }} state=started enabled=yes
   changed_when: False
+
+- name: Flush handlers to restart mongodb if necessary
+  meta: flush_handlers
+
+- name: Run mongoshell commands
+  command: mongo {{ item.key }} --eval "{{ item.value|join('\n') }}"
+  with_dict: mongodb_shell


### PR DESCRIPTION
This changes the order of the tasks executed for configuring mongodb. Make sure
mongodb is enabled and started before any shell commands are executed.
Additionally, flush handlers before executing shell commands. This makes sure
that mongodb was restarted if necessary before any shell commands are executed.

This fixes #23.